### PR TITLE
Adding stratcon ingestor

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,32 @@
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "phusion-open-ubuntu-14.04-amd64"
+  config.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-14.04-amd64-vbox.box"
+  # Or, for Ubuntu 12.04:
+  #config.vm.box = "phusion-open-ubuntu-12.04-amd64"
+  #config.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-12.04-amd64-vbox.box"
+
+  config.vm.provider :vmware_fusion do |f, override|
+    override.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-14.04-amd64-vmwarefusion.box"
+    #override.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-12.04-amd64-vmwarefusion.box"
+  end
+ config.vm.synced_folder ".", "/data"
+ config.vm.provision :shell, :inline => "sudo apt-get install -y node --no-install-recommends"
+ config.vm.provision :shell, :inline => "sudo apt-get install -y npm --no-install-recommends"
+
+  if Dir.glob("#{File.dirname(__FILE__)}/.vagrant/machines/default/*/id").empty?
+    # Install Docker
+    pkg_cmd = "wget -q -O - https://get.docker.io/gpg | apt-key add -;" \
+      "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list;" \
+      "apt-get update -qq; apt-get install -q -y --force-yes lxc-docker; "
+    # Add vagrant user to the docker group
+    pkg_cmd << "usermod -a -G docker vagrant; "
+    config.vm.provision :shell, :inline => pkg_cmd
+  end
+  config.vm.provision :shell, :inline => "sudo docker pull nachiket/postgres"
+  config.vm.provision :shell, :inline => "sudo docker pull nachiket/reconnoiter"
+  config.vm.provision :shell, :inline => "sudo docker pull dockerfile/redis"
+  config.vm.provision :shell, :inline => "sudo docker pull nachiket/stratcon_ingestor"
+end

--- a/lib/ingestor_client.js
+++ b/lib/ingestor_client.js
@@ -1,0 +1,59 @@
+var stratcon_stream = require('./stratcon_stream');
+var jlog_stream = require('./jlog_stream');
+var redis_stream = require('./redis_stream');
+var fs = require('fs');
+var http = require('http');
+var log = require('logmagic').local('ele.lib.noit.ingestor_client');
+
+
+/**
+* @param {String} noitHost noit host.
+* @param {Number} noitPort journal api port. 
+* @param {String} redisHost host for redis sink.
+* @param {Number} redisPort redis port number.
+* @constructor
+**/
+var IngestorClient = function(noitHost, noitPort, redisHost, redisPort) {
+  this.options = {
+    hostname: noitHost || 'localhost',
+    port: noitPort || 80,
+    path: '/handoff/journals',
+    method: 'GET'
+  };
+  this.type = 'stratcon';
+  this.redisPort = redisPort;
+  this.redisHost = redisHost;
+};
+
+
+/**
+* The ingest method which will start the ingestion.
+**/ 
+IngestorClient.prototype.ingest = function() {
+  var self = this;
+  var req = http.request(self.options, function(res) {
+    if (res.statusCode != 200) {
+      log.error('Response code should be 200. Aborting.', res.statusCode);
+      process.exit(1);
+    } else {
+      console.log('STATUS: ' + res.statusCode);
+      res.setEncoding('utf8');
+      res.pipe(stratcon_stream()).pipe(jlog_stream()).pipe(redis_stream(self.redisPort, self.redisHost));
+    }  
+  });
+
+  req.on('error', function(e) {
+    log.error('Problem with request. Exiting ingestion process.', e.message);
+    process.exit(1);
+  });
+
+  req.end();
+};
+
+
+/**
+* IngestorClient object.
+*/
+module.exports = function(noitHost, noitPort, redisHost, redisPort) {
+  return new IngestorClient(noitHost, noitPort, redisHost, redisPort);
+};

--- a/lib/jlog_stream.js
+++ b/lib/jlog_stream.js
@@ -1,0 +1,48 @@
+var Transform = require('stream').Transform;
+var util = require('util');
+var log = require('logmagic').local('ele.lib.noit.jlog_stream');
+
+
+/**
+* @constructor
+**/
+var ParseJlog = function() {
+  Transform.call(this);
+  this.type = 'stratcon';
+};
+util.inherits(ParseJlog, Transform);
+
+
+/**
+* A tranform which gets the journal data and pushes the metrics data. 
+* @param {Object} chunk The data being pumped into the stream.
+* @param {String} encoding encoding.
+* @param {Function} callback function to be called upon completion.
+**/
+ParseJlog.prototype._transform = function(chunk, encoding, callback) {
+  var lines = chunk.toString().split("\n"),
+  dataObjectArray = [];
+  lines.forEach(function(line) {
+    var dataObject = {},
+    fields = line.split("\t");
+    if (line.charAt(0) == 'B') {
+      if (line.charAt(1) == '1') {
+        dataObject.timestamp = fields[1]; 
+        dataObject.uuid = fields[2];
+        dataObject.data = line;
+        dataObjectArray.push(dataObject);
+      } else if (line.charAt(1) != '2') {
+        log.info('Unable to process line: Bad version');
+      }
+    }
+  });
+  callback(null, JSON.stringify(dataObjectArray)); 
+};
+
+
+/**
+* ParseJlog object.
+*/
+module.exports = function() {
+  return new ParseJlog();
+};

--- a/lib/redis_stream.js
+++ b/lib/redis_stream.js
@@ -1,0 +1,61 @@
+var redis = require('redis');
+var Writable = require('stream').Writable;
+var redis_stream = new Writable();
+var util = require('util');
+
+
+/**
+* @param {Number} port redis port
+* @param {String} host redis host
+* @constructor
+*/
+var RedisStream = function(port, host) {
+  var self = this;
+  Writable.call(this);
+  this.redisPort = port || 6379;
+  this.redisHost = host || 'localhost';
+  this.redisClient = redis.createClient(this.redisPort, this.redisHost, {});
+  this.on('pipe', function (source) {
+    // a label for this run, will allow us to store data for different test runs
+    self.label = source.type + '-' + Date.now();
+  });
+};
+util.inherits(RedisStream, Writable);
+
+
+/**
+* A Writeable stream which get the required metrics from journals
+* @param {Object} dataObjectArray array of metrics from one journal
+* @param {String} enc encoding
+* @param {Function} callback callback to be called after completion
+**/
+RedisStream.prototype._write = function(dataObjectArray, enc, callback) {
+  var self = this;
+  try {
+    dataObjectArray = JSON.parse(dataObjectArray);
+  } catch (e) {
+    callback();
+  }  
+  dataObjectArray.forEach(function(dataObject) {
+    // create a key for this check and the timestamp from this particualar metric chunk
+    var key = dataObject.uuid + ':' + dataObject.timestamp;
+    // stores the timestamp for this key
+    self.redisClient.hset(key, 'timestamp', dataObject.timestamp, redis.print);
+    // stores the encoded metric data for this key
+    self.redisClient.hset(key, 'data', dataObject.data, redis.print);
+    // set to store individual metrics and corresponding data
+    self.redisClient.sadd(dataObject.uuid, key, redis.print);
+    // a higher level set to store sets of metrics for checks
+    self.redisClient.sadd(self.label, dataObject.uuid, redis.print);
+    // to quickly see this in action : https://gist.github.com/ynachiket/bca3335c218b5e476800 
+  });
+  callback();
+};
+
+
+/**
+* RedisStream object.
+*/
+module.exports = function (port, host) {
+  return new RedisStream(port, host);
+};

--- a/lib/stratcon_stream.js
+++ b/lib/stratcon_stream.js
@@ -1,0 +1,52 @@
+var fs = require('fs');
+var redis = require('redis');
+var Transform = require('stream').Transform;
+var Writable = require('stream').Writable;
+var util = require('util');
+var path = require('path');
+var log = require('logmagic').local('ele.lib.noit.stratcon_stream');
+
+
+/**
+* @param {String} journalDir directry where noit writes jlog journals.
+* @constructor
+**/
+var StratconMetricsStream = function(journalDir) {
+  Transform.call(this);
+  this.journalDir = journalDir || '/var/log/stratcon.persist/127.0.0.1/noit-test/0/';
+};
+util.inherits(StratconMetricsStream, Transform);
+
+
+/**
+* A tranform which gets the journal filename and pushes the file contents. 
+* @param {Object} chunk The data being pumped into the stream.
+* @param {String} encoding encoding.
+* @param {Function} callback function to be called upon completion.
+**/
+StratconMetricsStream.prototype._transform = function(chunk, encoding, callback) {
+  var self = this;
+  chunk = chunk.toString(); // think about chunk being incomplete
+  if (chunk.indexOf('.h') > -1) {
+    var file = chunk.split(":")[1].split("/")[7].replace('\r\n','');
+    var stream = fs.createReadStream(path.join(this.journalDir, file));
+    stream.on('data', function(data) {
+      self.push(data);
+    });
+    stream.on('end', function () {
+      log.info('file has ended', path.join(self.journalDir, file));
+      callback();
+    });
+  } else {
+    callback();
+  }
+};
+
+
+/**
+* StratconMetricsStream object.
+*/
+module.exports = function(journalDir) {
+  return new StratconMetricsStream(journalDir);
+};
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noit_client",
   "description": "A client interface for Reconnoiter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "index.js",
   "directories": {
     "lib": "lib",
@@ -18,7 +18,11 @@
     "sprintf": "^0.1.1",
     "strtok": "^0.1.1",
     "underscore": "^1.7.0",
-    "zither": "0.1.6"
+    "zither": "0.1.6",
+    "redis": "0.10.0",
+    "longjohn": "~0.2.2",
+    "depends-on": "^1.1.0",
+    "async": "0.9.0"
   },
   "devDependencies": {
     "tape": "2.14.0",
@@ -26,8 +30,8 @@
     "istanbul": "0.3.2"
   },
   "scripts": {
-    "lint": "./node_modules/.bin/jshint ./lib ./test",
-    "test": "node test/*.js",
-    "coverage": "./node_modules/.bin/istanbul cover test/*.js"
+    "lint": "./node_modules/.bin/jshint ./lib ./tests",
+    "test": "nodejs tests/*.js",
+    "coverage": "./node_modules/.bin/istanbul cover tests/*.js"
   }
 }

--- a/tests/dependencies.json
+++ b/tests/dependencies.json
@@ -1,0 +1,70 @@
+  {
+  "postgres": {
+    "cmd": ["docker", "run", "-i", "-t",  "-p", "5432:5432", "--name", "postgres",
+     "-d", "nachiket/postgres"],
+    "wait_for": {
+      "exit_code": 0
+    },
+    "signal": "SIGKILL"
+
+  },
+  "noit_stratcon": {
+    "cmd": ["docker", "run", "-d", "-p", "32322:32322", "-p", "43191:43191", "-p",
+     "8888:8888", "-p", "80:80", "-ti", "--link", "postgres:postgres",
+      "-v", "/var/log/stratcon.persist/127.0.0.1/noit-test:/var/log/stratcon.persist/127.0.0.1/noit-test",
+       "--name", "noit", "nachiket/noit"],
+    "depends": ["postgres"],
+    "wait_for": {
+      "exit_code": 0
+    },
+    "signal": "SIGKILL"
+  },
+  "redis": {
+    "cmd": ["docker", "run", "-d", "--name", "redis", "-p", "6379:6379", "dockerfile/redis"],
+    "depends": ["noit_stratcon"],
+    "wait_for": {
+      "exit_code": 0
+    },
+    "signal": "SIGKILL"
+  },
+  "stratcon_ingestor": {
+    "cmd": ["docker", "run", "-d", "--name", "ingestor", "--link", "redis:redis",
+     "-v", "/var/log/stratcon.persist/127.0.0.1/noit-test:/var/log/stratcon.persist/127.0.0.1/noit-test",
+      "--link", "noit:noit", "nachiket/stratcon_ingestor"],
+    "depends": ["redis"],
+    "wait_for": {
+      "exit_code": 0
+    },
+    "signal": "SIGKILL"
+  },
+  "kill_postgres": {
+    "cmd": ["docker", "kill", "postgres"]
+  },
+  "kill_noit_stratcon": {
+    "cmd": ["docker", "kill", "noit"]
+  },
+  "remove_postgres": {
+     "cmd": ["docker", "rm", "-f", "postgres"],
+     "depends": ["kill_postgres"]
+  },
+  "remove_noit": {
+     "cmd": ["docker", "rm", "-f", "noit"],
+     "depends": ["kill_noit_stratcon"]
+  },
+  "kill_redis": {
+    "cmd": ["docker", "kill", "redis"],
+    "depends": ["kill_ingestor"]
+  },
+  "remove_redis": {
+     "cmd": ["docker", "rm", "-f", "redis"],
+     "depends": ["kill_redis"]
+  },
+  "kill_ingestor": {
+    "cmd": ["docker", "kill", "ingestor"],
+    "depends": ["kill_noit_stratcon"]
+  },
+  "remove_ingestor": {
+     "cmd": ["docker", "rm", "-f", "ingestor"],
+     "depends": ["kill_ingestor"]
+  } 
+}


### PR DESCRIPTION
Why:

This is to make sure that noit_client functionality can be tested end to end. One should be able to use the noit_client to create a test check and eventually see the the metrics for this specific check.

How: 

Adding the stratcon ingestor and client code to this library.
Using a pre built container harnessing the code from the stratcon ingestor components included

How to test:
vagrant up 
vagrant ssh 

Inside:
npm install
npm test

Under the hood:

I am using depends-on for process management. When you run npm test you will get
 -- a fully functional standalone noit instance
-- a stratcon ingestor which will ingest the metrics and put it in
-- a redis sink

We will then use the noit_client to do basic checks against this instance.
We will also configure a test check with a defined uuid.

We will then use a simple redis client to check for ingested metrics and also specifically check for the metrics for the newly created check with the known uuid.
