### PR TITLE
fix: do not retry deletes on 404

### DIFF
--- a/lib/noit_client.js
+++ b/lib/noit_client.js
@@ -205,6 +205,15 @@ NoitClient.prototype.sendrecv = function(method, path, payload, options, callbac
       });
       callback(null, res);
     }
+    else if (!err && res.statusCode === 404) {
+      log.debug('NoitClient sendrecv response', {
+        host: self.http_options.host,
+        port: self.http_options.port,
+        path: path,
+        statusCode: res.statusCode
+      });
+      callback(null, res);
+    }
     else if (!err && res.statusCode === 500) {
       self._handle500(method, path, body, callback);
     }


### PR DESCRIPTION
404 should not be considered an error, it is a valid response that should be handled by the caller imo.
